### PR TITLE
Improve macOS setup script with checks

### DIFF
--- a/scripts/macOS-native-setup.sh
+++ b/scripts/macOS-native-setup.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 # macOS-native-setup.sh
 
-# Install core dependencies
-brew update
-brew install python@3.11 tree-sitter coreutils
+# Verify Homebrew
+if ! command -v brew >/dev/null; then
+  echo "Homebrew is required but not installed. Please install Homebrew from https://brew.sh/"
+  exit 1
+fi
 
-# Install Ollama
-curl -fsSL https://ollama.ai/install.sh | sh
+# Install core dependencies if missing
+brew update
+for pkg in python@3.11 tree-sitter coreutils; do
+  if brew list "$pkg" >/dev/null 2>&1; then
+    echo "$pkg already installed"
+  else
+    brew install "$pkg"
+  fi
+done
+
+# Install Ollama if missing
+if ! command -v ollama >/dev/null; then
+  curl -fsSL https://ollama.ai/install.sh | sh
+else
+  echo "Ollama already installed"
+fi
 
 # Download optimized models
 ollama pull deepseek-coder:6.7b-q5_k_m
@@ -22,6 +38,12 @@ source ~/ai-env/bin/activate
 # Install Python dependencies
 pip install --upgrade pip
 pip install chromadb langchain-community sentence-transformers pypdf2 fastapi uvicorn continue
+
+# Ensure Node and npm are available
+if ! command -v npm >/dev/null; then
+  echo "npm is required but not installed. Please install Node.js first."
+  exit 1
+fi
 
 # Create project directory
 mkdir -p ~/vue-project/{src,docs}

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -6,6 +6,16 @@ echo "=== Service Status ==="
 if [ "$PLATFORM" = "mac" ]; then
     lsof -i :11434 && echo "Ollama: RUNNING"
     lsof -i :8000 && echo "ChromaDB: RUNNING"
+    if command -v python3.11 >/dev/null; then
+        echo "Python: $(python3.11 --version)"
+    else
+        echo "Python 3.11 not found"
+    fi
+    if command -v npm >/dev/null; then
+        echo "npm: $(npm --version)"
+    else
+        echo "npm not found"
+    fi
 elif [ "$PLATFORM" = "ubuntu" ]; then
     docker compose ps
 fi


### PR DESCRIPTION
## Summary
- check for Homebrew and skip reinstalling packages on macOS
- only install Ollama when it's missing
- confirm npm is available before project creation
- show Python and npm versions in `verify-setup.sh`

## Testing
- `pytest -q` *(fails: SyntaxError in src/agents/test_agent.py)*

------
https://chatgpt.com/codex/tasks/task_e_685a56f4c354832b927243243fe7c51e