### PR TITLE
Fix macOS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ chmod +x scripts/macOS-native-setup.sh
 ./scripts/macOS-native-setup.sh
 ```
 
+This setup script installs **Ollama** via Homebrew, so make sure Homebrew is available in your PATH.
+
 ### 2. Ubuntu Server (A4000) Setup
 
 ```bash

--- a/scripts/macOS-native-setup.sh
+++ b/scripts/macOS-native-setup.sh
@@ -19,7 +19,7 @@ done
 
 # Install Ollama if missing
 if ! command -v ollama >/dev/null; then
-  curl -fsSL https://ollama.ai/install.sh | sh
+  brew install ollama
 else
   echo "Ollama already installed"
 fi


### PR DESCRIPTION
## Summary
- use Homebrew for installing Ollama in macOS setup script
- document Homebrew usage in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement continue>=0.0.7)*
- `pytest -q` *(fails: SyntaxError in src/agents/test_agent.py)*

------
https://chatgpt.com/codex/tasks/task_e_685a59859158832bb5a06171cb80e0ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the macOS setup instructions in the README to clarify that Ollama is installed via Homebrew and to remind users to ensure Homebrew is available in their system PATH.

- **Chores**
  - Changed the macOS setup script to install Ollama using Homebrew instead of downloading it directly from the Ollama website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->