### PR TITLE
Add agent prompt methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ docker compose up -d
 
 # Generate from Figma design
 ./run_agent.sh generate_from_figma https://figma.com/file/12345
+
+# New code generation helpers
+./run_agent.sh generate_vue_component FancyButton '{"label": "string"}'
+./run_agent.sh generate_pinia_store cart '{"items": []}'
+./run_agent.sh generate_api_service userService '[{"method":"get","url":"/users"}]'
+./run_agent.sh configure_router '[{"path":"/about","component":"AboutView"}]'
 ```
 
 ### Run Tests and Optimizations

--- a/src/agents/agent_controller.py
+++ b/src/agents/agent_controller.py
@@ -12,6 +12,13 @@ except ModuleNotFoundError:
         def __init__(self, *args, **kwargs):
             raise RuntimeError("Continue package is not installed")
 from verification.orchestrator import VerificationPipeline
+from .prompt_templates import (
+    NEW_COMPONENT_TEMPLATE,
+    PINIA_STORE_TEMPLATE,
+    API_SERVICE_TEMPLATE,
+    ROUTER_CONFIG_TEMPLATE,
+    DEBUG_TEMPLATE,
+)
 import subprocess
 import os
 import requests
@@ -64,6 +71,135 @@ class AgentController:
 
         print(f"Generated component: {component_path}")
         return component_path
+
+    async def generate_vue_component(self, name, props=None, emits=None, slots=None, description=""):
+        """Generate Vue component using research prompts"""
+        component_path = f"src/components/{name}.vue"
+        os.makedirs(os.path.dirname(component_path), exist_ok=True)
+
+        prompt = NEW_COMPONENT_TEMPLATE.format(
+            name=name,
+            props=props or {},
+            emits=emits or [],
+            slots=slots or [],
+            description=description,
+        )
+
+        await self.c.edit(
+            filepath=component_path,
+            prompt=prompt,
+            context=[self.code_context],
+        )
+
+        print(f"Generated component: {component_path}")
+        return component_path
+
+    async def generate_pinia_store(self, name, state_definition, getters=None, actions=None, store_type="options"):
+        """Generate Pinia store following project rules"""
+        store_path = f"src/stores/{name}.ts"
+        os.makedirs(os.path.dirname(store_path), exist_ok=True)
+
+        prompt = PINIA_STORE_TEMPLATE.format(
+            name=name,
+            store_type=store_type,
+            state=state_definition,
+            getters=getters or {},
+            actions=actions or {},
+        )
+
+        await self.c.edit(
+            filepath=store_path,
+            prompt=prompt,
+            context=[self.code_context],
+        )
+
+        print(f"Generated Pinia store: {store_path}")
+        return store_path
+
+    async def generate_api_service(self, service_name, endpoints):
+        """Create Axios service file"""
+        service_path = f"src/services/{service_name}.ts"
+        os.makedirs(os.path.dirname(service_path), exist_ok=True)
+
+        prompt = API_SERVICE_TEMPLATE.format(name=service_name, endpoints=endpoints)
+
+        await self.c.edit(
+            filepath=service_path,
+            prompt=prompt,
+            context=[self.code_context],
+        )
+
+        print(f"Generated API service: {service_path}")
+        return service_path
+
+    async def configure_vue_router(self, routes):
+        """Update Vue Router configuration"""
+        router_path = "src/router/index.ts"
+        prompt = ROUTER_CONFIG_TEMPLATE.format(routes=routes)
+
+        await self.c.edit(
+            filepath=router_path,
+            prompt=prompt,
+            context=[self.code_context],
+        )
+
+        print("Updated router configuration")
+        return router_path
+
+    async def debug_code(self, code_snippet, error_message="", context=""):
+        """Use LLM to debug code snippet"""
+        prompt = DEBUG_TEMPLATE.format(code=code_snippet, error=error_message, context=context)
+        return await self.c.complete(prompt, max_tokens=800)
+
+    async def fix_api_issue(self, service_file_content, problem_description):
+        """Diagnose and fix API service issues"""
+        prompt = f"""{problem_description}\n\n{service_file_content}\nProvide a corrected version."""
+        return await self.c.complete(prompt, max_tokens=1200)
+
+    async def lint_and_fix(self, file_content):
+        """Fix ESLint issues in provided code"""
+        prompt = f"Lint and fix the following code according to project ESLint rules:\n{file_content}"
+        return await self.c.complete(prompt, max_tokens=800)
+
+    async def refactor_code(self, code_snippet, refactor_goal=""):
+        """Refactor code for readability and maintain strict typing"""
+        prompt = f"Refactor the following code to {refactor_goal} while keeping strict TypeScript:\n{code_snippet}"
+        return await self.c.complete(prompt, max_tokens=1200)
+
+    async def enforce_strict_typescript(self, code_snippet):
+        """Convert JavaScript code to strict TypeScript"""
+        prompt = f"Convert this code to strict TypeScript without using 'any':\n{code_snippet}"
+        return await self.c.complete(prompt, max_tokens=1200)
+
+    async def add_inline_comments(self, code_snippet):
+        """Add inline comments to code"""
+        prompt = f"Add concise inline comments to the following code:\n{code_snippet}"
+        return await self.c.complete(prompt, max_tokens=600)
+
+    async def generate_tsdoc(self, code_snippet, element_type):
+        """Generate TSDoc comments"""
+        prompt = f"Generate TSDoc comments for this {element_type}:\n{code_snippet}"
+        return await self.c.complete(prompt, max_tokens=800)
+
+    async def generate_readme_section(self, section_name, project_context):
+        """Generate README section"""
+        prompt = f"Write the {section_name} section of the README using this context:\n{project_context}"
+        return await self.c.complete(prompt, max_tokens=1000)
+
+    async def explain_task_implementation(self, high_level_task, current_codebase_context):
+        """Explain how to implement a high-level task"""
+        prompt = f"Explain how to implement the following task in code:\n{high_level_task}\nContext:\n{current_codebase_context}"
+        return await self.c.complete(prompt, max_tokens=1000)
+
+    async def generate_task_code_snippet(self, feature_description, component_context=""):
+        """Generate code snippet for a task"""
+        prompt = f"Generate code to implement this feature:\n{feature_description}\nContext:\n{component_context}"
+        return await self.c.complete(prompt, max_tokens=1000)
+
+    async def summarize_code_for_task(self, code_snippet, purpose=""):
+        """Summarize existing code for task updates"""
+        prompt = f"Summarize the following code for {purpose}:\n{code_snippet}"
+        return await self.c.complete(prompt, max_tokens=800)
 
     async def run_tests(self):
         """Run project tests"""
@@ -245,6 +381,37 @@ if __name__ == "__main__":
                 print("Usage: python agent_controller.py generate_component [name] [props]")
                 sys.exit(1)
             await agent.generate_component(sys.argv[2], json.loads(sys.argv[3]))
+
+        elif command == "generate_vue_component":
+            if len(sys.argv) < 3:
+                print("Usage: python agent_controller.py generate_vue_component [name]")
+                sys.exit(1)
+            name = sys.argv[2]
+            props = json.loads(sys.argv[3]) if len(sys.argv) > 3 else None
+            await agent.generate_vue_component(name, props)
+
+        elif command == "generate_pinia_store":
+            if len(sys.argv) < 4:
+                print("Usage: python agent_controller.py generate_pinia_store [name] [state_json]")
+                sys.exit(1)
+            name = sys.argv[2]
+            state = json.loads(sys.argv[3])
+            await agent.generate_pinia_store(name, state)
+
+        elif command == "generate_api_service":
+            if len(sys.argv) < 4:
+                print("Usage: python agent_controller.py generate_api_service [name] [endpoints_json]")
+                sys.exit(1)
+            name = sys.argv[2]
+            endpoints = json.loads(sys.argv[3])
+            await agent.generate_api_service(name, endpoints)
+
+        elif command == "configure_router":
+            if len(sys.argv) < 3:
+                print("Usage: python agent_controller.py configure_router [routes_json]")
+                sys.exit(1)
+            routes = json.loads(sys.argv[2])
+            await agent.configure_vue_router(routes)
 
         elif command == "setup_feature":
             if len(sys.argv) < 3:

--- a/src/agents/prompt_templates.py
+++ b/src/agents/prompt_templates.py
@@ -1,0 +1,43 @@
+# Prompt templates for AgentController methods
+# These are simplified prompts derived from `.github/prompt-research.md`
+# and `.github/extra-prompts.md`.
+# They guide the Continue API to generate Vue 3 code following project rules.
+
+NEW_COMPONENT_TEMPLATE = """
+Create a Vue 3 component named `{name}` using <script setup lang='ts'>.
+Props: {props}
+Emits: {emits}
+Slots: {slots}
+{description}
+Follow project rules: <script> before <template>, use Tailwind CSS, place types in ./types and avoid <style> blocks.
+"""
+
+PINIA_STORE_TEMPLATE = """
+Generate a Pinia store named `{name}` with {store_type} syntax.
+State definition: {state}
+Getters: {getters}
+Actions: {actions}
+Use strict TypeScript and output to src/stores.
+"""
+
+API_SERVICE_TEMPLATE = """
+Create an Axios service `{name}` handling these endpoints:
+{endpoints}
+Use humps for camelCase conversion and TypeScript interfaces for requests and responses.
+"""
+
+ROUTER_CONFIG_TEMPLATE = """
+Update Vue Router configuration with the following routes:
+{routes}
+Use createWebHistory and strict TypeScript definitions.
+"""
+
+DEBUG_TEMPLATE = """
+Given this code:
+{code}
+And error:
+{error}
+{context}
+Suggest a clear fix.
+"""
+


### PR DESCRIPTION
## Summary
- integrate extra prompt research in new prompt templates
- extend `AgentController` with code generation, debugging and documentation helpers
- expose new CLI commands
- document new commands in README

## Testing
- `python -m py_compile src/agents/agent_controller.py src/agents/prompt_templates.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a697386fc832b961dc9728cb2ac24