### PR TITLE
Fix macOS setup paths

### DIFF
--- a/src/agents/accessibility_agent.py
+++ b/src/agents/accessibility_agent.py
@@ -12,7 +12,8 @@ class AccessibilityAgent:
     def __init__(self):
         """Initialize accessibility agent"""
         self.c = AgentController()
-        self.results_dir = os.path.expanduser("~/vue-project/tests/accessibility")
+        self.project_dir = os.getenv("VUE_PROJECT_DIR", os.path.expanduser("~/vue-project"))
+        self.results_dir = os.path.join(self.project_dir, "tests", "accessibility")
         os.makedirs(self.results_dir, exist_ok=True)
 
     async def audit_component(self, component_name, props=None, standard="wcag21aa"):
@@ -362,7 +363,7 @@ class AccessibilityAgent:
         print("Starting accessibility monitoring")
 
         # Find all Vue components
-        component_dir = os.path.expanduser("~/vue-project/src/components")
+        component_dir = os.path.join(self.project_dir, "src", "components")
         if not os.path.exists(component_dir):
             print(f"Component directory not found: {component_dir}")
             return {

--- a/src/agents/performance_agent.py
+++ b/src/agents/performance_agent.py
@@ -11,7 +11,8 @@ class PerformanceAgent:
     def __init__(self):
         """Initialize performance benchmarking agent"""
         self.c = AgentController()
-        self.results_dir = os.path.expanduser("~/vue-project/tests/performance")
+        self.project_dir = os.getenv("VUE_PROJECT_DIR", os.path.expanduser("~/vue-project"))
+        self.results_dir = os.path.join(self.project_dir, "tests", "performance")
         os.makedirs(self.results_dir, exist_ok=True)
 
     async def benchmark_component(self, component_name, props=None, iterations=50):

--- a/src/agents/visual_test_agent.py
+++ b/src/agents/visual_test_agent.py
@@ -11,7 +11,8 @@ class VisualRegressionAgent:
     def __init__(self):
         """Initialize visual regression testing agent"""
         self.c = AgentController()
-        self.screenshot_dir = os.path.expanduser("~/vue-project/tests/screenshots")
+        self.project_dir = os.getenv("VUE_PROJECT_DIR", os.path.expanduser("~/vue-project"))
+        self.screenshot_dir = os.path.join(self.project_dir, "tests", "screenshots")
         self.baseline_dir = os.path.join(self.screenshot_dir, "baseline")
         self.current_dir = os.path.join(self.screenshot_dir, "current")
         self.diff_dir = os.path.join(self.screenshot_dir, "diff")
@@ -231,7 +232,7 @@ class VisualRegressionAgent:
         print("Running visual regression test pipeline")
 
         # Find all Vue components
-        component_dir = os.path.expanduser("~/vue-project/src/components")
+        component_dir = os.path.join(self.project_dir, "src", "components")
         if not os.path.exists(component_dir):
             print(f"Component directory not found: {component_dir}")
             return {"status": "error", "message": "Component directory not found"}

--- a/src/rag_indexer.py
+++ b/src/rag_indexer.py
@@ -37,8 +37,12 @@ def index_codebase(include_docs=None, include_external=None, reindex=False):
     )
 
     # Index code files
+    project_src = os.path.join(
+        os.getenv("VUE_PROJECT_DIR", os.path.expanduser("~/vue-project")),
+        "src"
+    )
     loader = DirectoryLoader(
-        os.path.expanduser("~/vue-project/src"),
+        project_src,
         glob="**/*.{vue,ts,js,md}"
     )
 
@@ -74,7 +78,7 @@ def index_codebase(include_docs=None, include_external=None, reindex=False):
     )
 
     # Index resources using KnowledgeHub
-    knowledge_hub.index_resource("~/vue-project/src", "code")
+    knowledge_hub.index_resource(project_src, "code")
 
     print(f"Indexed {len(chunks)} code/documentation chunks")
 


### PR DESCRIPTION
## Summary
- ensure macOS setup script uses working directory
- avoid copying Python helpers to vue-project
- support configurable project path in agents

## Testing
- `python -m py_compile src/rag_indexer.py src/agents/visual_test_agent.py src/agents/accessibility_agent.py src/agents/performance_agent.py`
- `shellcheck scripts/macOS-native-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a72473274832ba29cd83972d50d66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated all agents and related scripts to dynamically determine the base project directory from an environment variable, improving flexibility and portability.
  - Unified path handling across scripts and agents, replacing hardcoded paths with environment-based or dynamically resolved paths.
  - Improved user instructions and script portability by using relative and dynamically resolved paths.
  - Removed unnecessary copying of indexing scripts in setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->